### PR TITLE
Remaining changes to support upip low-heap operation

### DIFF
--- a/make_metadata.py
+++ b/make_metadata.py
@@ -9,7 +9,7 @@ import glob
 TEMPLATE = """\
 import sys
 # Remove current dir from sys.path, otherwise setuptools will peek up our
-# module instead of system.
+# module instead of system's.
 sys.path.pop(0)
 from setuptools import setup
 sys.path.append("..")

--- a/make_metadata.py
+++ b/make_metadata.py
@@ -12,7 +12,8 @@ import sys
 # module instead of system.
 sys.path.pop(0)
 from setuptools import setup
-
+sys.path.append("..")
+import optimize_upip
 
 setup(name='micropython-%(dist_name)s',
       version='%(version)s',
@@ -24,6 +25,7 @@ setup(name='micropython-%(dist_name)s',
       maintainer=%(maintainer)r,
       maintainer_email='micro-python@googlegroups.com',
       license=%(license)r,
+      cmdclass={'optimize_upip': optimize_upip.OptimizeUpip},
       %(_what_)s=[%(modules)s]%(_inst_req_)s)
 """
 

--- a/optimize_upip.py
+++ b/optimize_upip.py
@@ -1,0 +1,106 @@
+#
+# This script optimizes a Python source distribution tarball as produced by
+# "python3 setup.py sdist" command for MicroPython's native package manager,
+# upip. Optimization includes:
+#  * Removing metadata files not used by upip (this includes setup.py)
+#  * Recompressing gzip archive with 4K dictionary size so it can be
+#    installed even on low-heap targets.
+#
+import sys
+import os
+import zlib
+from subprocess import Popen, PIPE
+import glob
+import tarfile
+import re
+import io
+
+
+def gzip_4k(inf, fname):
+    comp = zlib.compressobj(level=9, wbits=16 + 12)
+    with open(fname + ".out", "wb") as outf:
+        while 1:
+            data = inf.read(1024)
+            if not data:
+                break
+            outf.write(comp.compress(data))
+        outf.write(comp.flush())
+    os.rename(fname, fname + ".org")
+    os.rename(fname + ".out", fname)
+
+
+def recompress(fname):
+    with Popen(["gzip", "-d", "-c", fname], stdout=PIPE).stdout as inf:
+        gzip_4k(inf, fname)
+
+def find_latest(dir):
+    res = []
+    for fname in glob.glob(dir + "/*.gz"):
+        st = os.stat(fname)
+        res.append((st.st_mtime, fname))
+    res.sort()
+    latest = res[-1][1]
+    return latest
+
+
+def recompress_latest(dir):
+    latest = find_latest(dir)
+    print(latest)
+    recompress(latest)
+
+
+EXCLUDE = [r".+/setup.py"]
+INCLUDE = [r".+\.py", r".+\.egg-info/(PKG-INFO|requires\.txt)"]
+
+
+outbuf = io.BytesIO()
+
+def filter_tar(name):
+    fin = tarfile.open(name, "r:gz")
+    fout = tarfile.open(fileobj=outbuf, mode="w")
+    for info in fin:
+#        print(info)
+        include = None
+        for p in EXCLUDE:
+            if re.match(p, info.name):
+                include = False
+                break
+        if include is None:
+            for p in INCLUDE:
+                if re.match(p, info.name):
+                    include = True
+                    print("Including:", info.name)
+        if not include:
+            continue
+        farch = fin.extractfile(info)
+        fout.addfile(info, farch)
+    fout.close()
+    fin.close()
+
+
+
+from setuptools import Command
+
+class OptimizeUpip(Command):
+
+    user_options = []
+
+    def run(self):
+        latest = find_latest("dist")
+        filter_tar(latest)
+        outbuf.seek(0)
+        gzip_4k(outbuf, latest)
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+
+# For testing only
+if __name__ == "__main__":
+#    recompress_latest(sys.argv[1])
+    filter_tar(sys.argv[1])
+    outbuf.seek(0)
+    gzip_4k(outbuf, sys.argv[1])

--- a/pystone_lowmem/metadata.txt
+++ b/pystone_lowmem/metadata.txt
@@ -1,3 +1,3 @@
 srctype = cpython
 type = module
-version = 3.4.2-2
+version = 3.4.2-3

--- a/pystone_lowmem/setup.py
+++ b/pystone_lowmem/setup.py
@@ -1,12 +1,13 @@
 import sys
 # Remove current dir from sys.path, otherwise setuptools will peek up our
-# module instead of system.
+# module instead of system's.
 sys.path.pop(0)
 from setuptools import setup
-
+sys.path.append("..")
+import optimize_upip
 
 setup(name='micropython-pystone_lowmem',
-      version='3.4.2-2',
+      version='3.4.2-3',
       description='CPython pystone_lowmem module ported to MicroPython',
       long_description='This is a module ported from CPython standard library to be compatible with\nMicroPython interpreter. Usually, this means applying small patches for\nfeatures not supported (yet, or at all) in MicroPython. Sometimes, heavier\nchanges are required. Note that CPython modules are written with availability\nof vast resources in mind, and may not work for MicroPython ports with\nlimited heap. If you are affected by such a case, please help reimplement\nthe module from scratch.',
       url='https://github.com/micropython/micropython/issues/405',
@@ -15,4 +16,5 @@ setup(name='micropython-pystone_lowmem',
       maintainer='MicroPython Developers',
       maintainer_email='micro-python@googlegroups.com',
       license='Python',
+      cmdclass={'optimize_upip': optimize_upip.OptimizeUpip},
       py_modules=['pystone_lowmem'])

--- a/upip/metadata.txt
+++ b/upip/metadata.txt
@@ -1,6 +1,6 @@
 srctype = micropython-lib
 type = module
-version = 1.0
+version = 1.1
 author = Paul Sokolovsky
 extra_modules = upip_utarfile
 desc = Simple package manager for MicroPython.

--- a/upip/setup.py
+++ b/upip/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 
 setup(name='micropython-upip',
-      version='1.0',
+      version='1.1',
       description='Simple package manager for MicroPython.',
       long_description='Simple self-hosted package manager for MicroPython (requires usocket, ussl, uzlib, uctypes builtin modules). Compatible only with packages without custom setup.py code.',
       url='https://github.com/micropython/micropython/issues/405',

--- a/upip/upip.py
+++ b/upip/upip.py
@@ -1,9 +1,11 @@
 import sys
+import gc
 import uos as os
 import uerrno as errno
 import ujson as json
 import uzlib
 import upip_utarfile as tarfile
+gc.collect()
 
 
 debug = False
@@ -148,6 +150,8 @@ def install_pkg(pkg_spec, install_path):
 
     latest_ver = data["info"]["version"]
     packages = data["releases"][latest_ver]
+    del data
+    gc.collect()
     assert len(packages) == 1
     package_url = packages[0]["url"]
     print("Installing %s %s from %s" % (pkg_spec, latest_ver, package_url))
@@ -157,6 +161,9 @@ def install_pkg(pkg_spec, install_path):
     f3 = tarfile.TarFile(fileobj=f2)
     meta = install_tar(f3, install_path)
     f1.close()
+    del f3
+    del f2
+    gc.collect()
     return meta
 
 def install(to_install, install_path=None):

--- a/upip/upip.py
+++ b/upip/upip.py
@@ -89,8 +89,9 @@ def install_tar(f, prefix):
     return meta
 
 def expandhome(s):
-    h = os.getenv("HOME")
-    s = s.replace("~/", h + "/")
+    if "~/" in s:
+        h = os.getenv("HOME")
+        s = s.replace("~/", h + "/")
     return s
 
 import ussl

--- a/upip/upip.py
+++ b/upip/upip.py
@@ -35,7 +35,9 @@ def _makedirs(name, mode=0o777):
     ret = False
     s = ""
     for c in name.rstrip("/").split("/"):
-        s += c + "/"
+        if s:
+            s += "/"
+        s += c
         try:
             os.mkdir(s)
             ret = True

--- a/upip/upip.py
+++ b/upip/upip.py
@@ -120,11 +120,13 @@ def url_open(url):
     l = s.readline()
     protover, status, msg = l.split(None, 2)
     if status != b"200":
-        raise OSError()
+        if status == b"404":
+            print("Package not found")
+        raise ValueError(status)
     while 1:
         l = s.readline()
         if not l:
-            raise OSError()
+            raise ValueError("Unexpected EOF")
         if l == b'\r\n':
             break
 

--- a/upip/upip.py
+++ b/upip/upip.py
@@ -31,10 +31,11 @@ def op_split(path):
 def op_basename(path):
     return op_split(path)[1]
 
+# Expects *file* name
 def _makedirs(name, mode=0o777):
     ret = False
     s = ""
-    for c in name.rstrip("/").split("/"):
+    for c in name.rstrip("/").split("/")[:-1]:
         if s:
             s += "/"
         s += c
@@ -80,12 +81,10 @@ def install_tar(f, prefix):
 
         if save:
             outfname = prefix + fname
-            if info.type == tarfile.DIRTYPE:
-                if _makedirs(outfname):
-                    print("Created " + outfname)
-            else:
+            if info.type != tarfile.DIRTYPE:
                 if debug:
                     print("Extracting " + outfname)
+                _makedirs(outfname)
                 subf = f.extractfile(info)
                 save_file(outfname, subf)
     return meta

--- a/upip/upip.py
+++ b/upip/upip.py
@@ -6,8 +6,6 @@ import uzlib
 import upip_utarfile as tarfile
 
 
-DEFAULT_MICROPYPATH = "~/.micropython/lib:/usr/lib/micropython"
-
 debug = False
 install_path = None
 cleanup_files = []
@@ -192,12 +190,8 @@ def install(to_install, install_path=None):
 def get_install_path():
     global install_path
     if install_path is None:
-        if hasattr(os, "getenv"):
-            install_path = os.getenv("MICROPYPATH")
-        if install_path is None:
-            # sys.path[0] is current module's path
-            install_path = sys.path[1]
-    install_path = install_path.split(":", 1)[0]
+        # sys.path[0] is current module's path
+        install_path = sys.path[1]
     install_path = expandhome(install_path)
     return install_path
 
@@ -213,11 +207,15 @@ def help():
 upip - Simple PyPI package manager for MicroPython
 Usage: micropython -m upip install [-p <path>] <package>... | -r <requirements.txt>
 
-If -p is not given, packages will be installed to first path component of
-MICROPYPATH, or to ~/.micropython/lib/ by default.
-Note: only MicroPython packages (usually, micropython-*) are supported for
-installation, upip does not support arbitrary code in setup.py.""")
-    sys.exit(1)
+If <path> is not given, packages will be installed into sys.path[1]
+(can be set from MICROPYPATH environment variable, if current system
+supports that).""")
+    print("Current value of sys.path[1]:", sys.path[1])
+    print("""\
+
+Note: only MicroPython packages (usually, named micropython-*) are supported
+for installation, upip does not support arbitrary code in setup.py.
+""")
 
 def main():
     global debug
@@ -226,6 +224,7 @@ def main():
 
     if len(sys.argv) < 2 or sys.argv[1] == "-h" or sys.argv[1] == "--help":
         help()
+        return
 
     if sys.argv[1] != "install":
         fatal("Only 'install' command supported")
@@ -238,6 +237,7 @@ def main():
         i += 1
         if opt == "-h" or opt == "--help":
             help()
+            return
         elif opt == "-p":
             install_path = sys.argv[i]
             i += 1
@@ -258,6 +258,7 @@ def main():
     to_install.extend(sys.argv[i:])
     if not to_install:
         help()
+        return
 
     install(to_install)
 

--- a/upip/upip.py
+++ b/upip/upip.py
@@ -206,6 +206,7 @@ def help():
     print("""\
 upip - Simple PyPI package manager for MicroPython
 Usage: micropython -m upip install [-p <path>] <package>... | -r <requirements.txt>
+import upip; upip.install(package_or_list, [<path>])
 
 If <path> is not given, packages will be installed into sys.path[1]
 (can be set from MICROPYPATH environment variable, if current system

--- a/upip/upip.py
+++ b/upip/upip.py
@@ -9,6 +9,7 @@ import upip_utarfile as tarfile
 debug = False
 install_path = None
 cleanup_files = []
+gzdict_sz = 16 + 15
 
 file_buf = bytearray(512)
 
@@ -152,13 +153,19 @@ def install_pkg(pkg_spec, install_path):
     print("Installing %s %s from %s" % (pkg_spec, latest_ver, package_url))
     package_fname = op_basename(package_url)
     f1 = url_open(package_url)
-    f2 = uzlib.DecompIO(f1, 16 + 15)
+    f2 = uzlib.DecompIO(f1, gzdict_sz)
     f3 = tarfile.TarFile(fileobj=f2)
     meta = install_tar(f3, install_path)
     f1.close()
     return meta
 
 def install(to_install, install_path=None):
+    # Calculate gzip dictionary size to use
+    global gzdict_sz
+    sz = gc.mem_free() + gc.mem_alloc()
+    if sz <= 655360:
+        gzdict_sz = 16 + 12
+
     if install_path is None:
         install_path = get_install_path()
     if install_path[-1] != "/":

--- a/upip/upip_utarfile.py
+++ b/upip/upip_utarfile.py
@@ -39,7 +39,13 @@ class FileSection:
         return sz
 
     def skip(self):
-        self.f.read(self.content_len + self.align)
+        sz = self.content_len + self.align
+        if sz:
+            buf = bytearray(16)
+            while sz:
+                s = min(sz, 16)
+                self.f.readinto(buf, s)
+                sz -= s
 
 class TarInfo:
 

--- a/upip/upip_utarfile.py
+++ b/upip/upip_utarfile.py
@@ -12,12 +12,6 @@ REGTYPE = "file"
 def roundup(val, align):
     return (val + align - 1) & ~(align - 1)
 
-def skip(f, size):
-    assert size % 512 == 0
-    buf = bytearray(512)
-    while size:
-        size -= f.readinto(buf)
-
 class FileSection:
 
     def __init__(self, f, content_len, aligned_len):

--- a/utarfile/metadata.txt
+++ b/utarfile/metadata.txt
@@ -1,5 +1,5 @@
 srctype = micropython-lib
 type = module
-version = 0.3
+version = 0.3.1
 author = Paul Sokolovsky
 long_desc = Lightweight tarfile module subset

--- a/utarfile/setup.py
+++ b/utarfile/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 
 setup(name='micropython-utarfile',
-      version='0.3',
+      version='0.3.1',
       description='utarfile module for MicroPython',
       long_description='Lightweight tarfile module subset',
       url='https://github.com/micropython/micropython/issues/405',

--- a/utarfile/utarfile.py
+++ b/utarfile/utarfile.py
@@ -12,12 +12,6 @@ REGTYPE = "file"
 def roundup(val, align):
     return (val + align - 1) & ~(align - 1)
 
-def skip(f, size):
-    assert size % 512 == 0
-    buf = bytearray(512)
-    while size:
-        size -= f.readinto(buf)
-
 class FileSection:
 
     def __init__(self, f, content_len, aligned_len):


### PR DESCRIPTION
These are remaining changes to make upip be runnable on esp8266. @dpgeorge, if you have any comments, please share them, otherwise I plan to merge this soon and proceed with re-uploading 4K-optimized packages to PyPI. Note that micropython-pystone_lowmem already uploaded in 4K version for testing.
