### PR TITLE
uuid: provide UUID class and random uuid4() implementation

### DIFF
--- a/uuid/metadata.txt
+++ b/uuid/metadata.txt
@@ -1,3 +1,6 @@
-srctype=dummy
-type=module
-version = 0.0.1
+srctype = micropython-lib
+type = module
+version = 0.0.2
+depends = os
+author = Andrew Leech
+author_email = andrew@alelec.net

--- a/uuid/setup.py
+++ b/uuid/setup.py
@@ -7,14 +7,15 @@ sys.path.append("..")
 import sdist_upip
 
 setup(name='micropython-uuid',
-      version='0.0.1',
-      description='Dummy uuid module for MicroPython',
-      long_description='This is a dummy implementation of a module for MicroPython standard library.\nIt contains zero or very little functionality, and primarily intended to\navoid import errors (using idea that even if an application imports a\nmodule, it may be not using it onevery code path, so may work at least\npartially). It is expected that more complete implementation of the module\nwill be provided later. Please help with the development if you are\ninterested in this module.',
+      version='0.0.2',
+      description='uuid module for MicroPython',
+      long_description="This is a module reimplemented specifically for MicroPython standard library,\nwith efficient and lean design in mind. Note that this module is likely work\nin progress and likely supports just a subset of CPython's corresponding\nmodule. Please help with the development if you are interested in this\nmodule.",
       url='https://github.com/pfalcon/micropython-lib',
-      author='Paul Sokolovsky',
-      author_email='micropython-lib@googlegroups.com',
+      author='Andrew Leech',
+      author_email='andrew@alelec.net',
       maintainer='Paul Sokolovsky',
       maintainer_email='micropython-lib@googlegroups.com',
       license='MIT',
       cmdclass={'sdist': sdist_upip.sdist},
-      py_modules=['uuid'])
+      py_modules=['uuid'],
+      install_requires=['micropython-os'])

--- a/uuid/test_uuid.py
+++ b/uuid/test_uuid.py
@@ -1,0 +1,31 @@
+import uuid
+
+u1 = uuid.uuid4()
+u2 = uuid.uuid4()
+
+assert str(u1) != str(u2), "Two uuid4 should not match"
+
+same = {
+    uuid.UUID('{12345678-1234-5678-1234-567812345678}'),
+    uuid.UUID('12345678123456781234567812345678'),
+    uuid.UUID('12345678-1234-5678-1234-567812345678'),
+    uuid.UUID(bytes=b'\x12\x34\x56\x78'*4),
+    uuid.UUID(bytes_le=b'\x78\x56\x34\x12\x34\x12\x78\x56' +
+                  b'\x12\x34\x56\x78\x12\x34\x56\x78'),
+    uuid.UUID(fields=(0x12345678, 0x1234, 0x5678, 0x12, 0x34, 0x567812345678)),
+    uuid.UUID(int=0x12345678123456781234567812345678)
+}
+
+print(same)
+
+assert len(same) == 1, "Alternate methods of initialising UUID should match"
+
+u3 = same.pop()
+
+assert str(u3) == '12345678-1234-5678-1234-567812345678', "str convertion should create standard uuid representation"
+
+assert u3.hex == '12345678123456781234567812345678'
+
+assert u3.__bytes__() == b'\x12\x34\x56\x78'*4
+
+print("OK")

--- a/uuid/test_uuid.py
+++ b/uuid/test_uuid.py
@@ -5,27 +5,11 @@ u2 = uuid.uuid4()
 
 assert str(u1) != str(u2), "Two uuid4 should not match"
 
-same = {
-    uuid.UUID('{12345678-1234-5678-1234-567812345678}'),
-    uuid.UUID('12345678123456781234567812345678'),
-    uuid.UUID('12345678-1234-5678-1234-567812345678'),
-    uuid.UUID(bytes=b'\x12\x34\x56\x78'*4),
-    uuid.UUID(bytes_le=b'\x78\x56\x34\x12\x34\x12\x78\x56' +
-                  b'\x12\x34\x56\x78\x12\x34\x56\x78'),
-    uuid.UUID(fields=(0x12345678, 0x1234, 0x5678, 0x12, 0x34, 0x567812345678)),
-    uuid.UUID(int=0x12345678123456781234567812345678)
-}
+assert len(str(u1)) == len(str(u1)) == 36
 
-print(same)
+assert str(repr(u1)).startswith("<UUID")
+assert str(repr(u1)).endswith(">")
 
-assert len(same) == 1, "Alternate methods of initialising UUID should match"
-
-u3 = same.pop()
-
-assert str(u3) == '12345678-1234-5678-1234-567812345678', "str convertion should create standard uuid representation"
-
-assert u3.hex == '12345678123456781234567812345678'
-
-assert u3.__bytes__() == b'\x12\x34\x56\x78'*4
+assert len(u1.hex) == 32
 
 print("OK")

--- a/uuid/uuid.py
+++ b/uuid/uuid.py
@@ -1,0 +1,80 @@
+'''Implements basic interface of UUID and uuid4()
+'''
+import os
+import ubinascii
+
+# The cpython UUID class takes "int" as argument name 
+# but we need to reference real int function below
+_from_bytes = int.from_bytes
+
+
+class UUID:
+    def __init__(self, hex=None, bytes=None, bytes_le=None, fields=None, int=None):
+        if hex:
+            b = ubinascii.unhexlify(hex.strip('{}').replace('-', ''))
+            if len(b) != 16:
+                raise ValueError('string args must be in long uuid format')
+            self._int = _from_bytes(b, 'big')
+
+        elif bytes:
+            if len(bytes) != 16:
+                raise ValueError('bytes must be 16 bytes')
+            self._int = _from_bytes(bytes, 'big')
+
+        elif bytes_le:
+            if len(bytes_le) != 16:
+                raise ValueError('bytes_le must be 16 bytes')
+            self._int = _from_bytes(bytes_le[:4], 'little') << 96
+            self._int |= _from_bytes(bytes_le[4:6], 'little') << 80
+            self._int |= _from_bytes(bytes_le[6:8], 'little') << 64
+            self._int |= _from_bytes(bytes_le[8:], 'big')
+
+
+        elif fields:
+            if len(fields) != 6:
+                raise ValueError('fields must be the six integer fields of the UUID')
+            self._int = fields[0]<<96
+            self._int |= fields[1]<<80
+            self._int |= fields[2]<<64
+            self._int |= fields[3]<<56
+            self._int |= fields[4]<<48
+            self._int |= fields[5]<<0
+
+        elif int:
+            self._int = int
+
+        else:
+            raise ValueError("No valid argument passed")
+
+    @property
+    def hex(self):
+        return '%032x' % self._int
+            
+    def __str__(self):
+        hex = '%032x' % self._int
+        return '%s-%s-%s-%s-%s' % (
+               hex[:8], hex[8:12], hex[12:16], hex[16:20], hex[20:])
+
+    def __repr__(self):
+        return "<UUID: {%s}>" % str(self)
+
+    def __bytes__(self):
+        return self._int.to_bytes(16, 'big')
+
+    def __int__(self):
+        return self._int
+
+    def __hash__(self):
+        return hash(self._int)
+
+    def __eq__(self, other):
+        if isinstance(other, UUID):
+            return other.__int__() == self._int
+
+
+def uuid4():
+    '''Generates a random UUID compliant to RFC 4122 pg.14 '''
+    random = bytearray(os.urandom(16))
+    random[6] = (random[6] & 0x0F) | 0x40
+    random[8] = (random[8] & 0x3F) | 0x80
+    return UUID(bytes=random)

--- a/uuid/uuid.py
+++ b/uuid/uuid.py
@@ -1,79 +1,27 @@
-'''Implements basic interface of UUID and uuid4()
-'''
 import os
 import ubinascii
 
-# The cpython UUID class takes "int" as argument name 
-# but we need to reference real int function below
-_from_bytes = int.from_bytes
-
 
 class UUID:
-    def __init__(self, hex=None, bytes=None, bytes_le=None, fields=None, int=None):
-        if hex:
-            b = ubinascii.unhexlify(hex.strip('{}').replace('-', ''))
-            if len(b) != 16:
-                raise ValueError('string args must be in long uuid format')
-            self._int = _from_bytes(b, 'big')
-
-        elif bytes:
-            if len(bytes) != 16:
-                raise ValueError('bytes must be 16 bytes')
-            self._int = _from_bytes(bytes, 'big')
-
-        elif bytes_le:
-            if len(bytes_le) != 16:
-                raise ValueError('bytes_le must be 16 bytes')
-            self._int = _from_bytes(bytes_le[:4], 'little') << 96
-            self._int |= _from_bytes(bytes_le[4:6], 'little') << 80
-            self._int |= _from_bytes(bytes_le[6:8], 'little') << 64
-            self._int |= _from_bytes(bytes_le[8:], 'big')
-
-
-        elif fields:
-            if len(fields) != 6:
-                raise ValueError('fields must be the six integer fields of the UUID')
-            self._int = fields[0]<<96
-            self._int |= fields[1]<<80
-            self._int |= fields[2]<<64
-            self._int |= fields[3]<<56
-            self._int |= fields[4]<<48
-            self._int |= fields[5]<<0
-
-        elif int:
-            self._int = int
-
-        else:
-            raise ValueError("No valid argument passed")
+    def __init__(self, bytes):
+        if len(bytes) != 16:
+            raise ValueError('bytes arg must be 16 bytes long')
+        self._bytes = bytes
 
     @property
     def hex(self):
-        return '%032x' % self._int
-            
+        return ubinascii.hexlify(self._bytes).decode()
+
     def __str__(self):
-        hex = '%032x' % self._int
-        return '%s-%s-%s-%s-%s' % (
-               hex[:8], hex[8:12], hex[12:16], hex[16:20], hex[20:])
+        h = self.hex
+        return '-'.join((h[0:8], h[8:12], h[12:16], h[16:20], h[20:32]))
 
     def __repr__(self):
-        return "<UUID: {%s}>" % str(self)
-
-    def __bytes__(self):
-        return self._int.to_bytes(16, 'big')
-
-    def __int__(self):
-        return self._int
-
-    def __hash__(self):
-        return hash(self._int)
-
-    def __eq__(self, other):
-        if isinstance(other, UUID):
-            return other.__int__() == self._int
+        return "<UUID: %s>" % str(self)
 
 
 def uuid4():
-    '''Generates a random UUID compliant to RFC 4122 pg.14 '''
+    """ Generates a random UUID compliant to RFC 4122 pg.14 """
     random = bytearray(os.urandom(16))
     random[6] = (random[6] & 0x0F) | 0x40
     random[8] = (random[8] & 0x3F) | 0x80


### PR DESCRIPTION
This provides class `uuid.UUID(bytes=None)` 

`bytes` arg takes a 16-long bytes or bytearray object and provides a UUID class with `__str__()` function and `hex` property. 

The function `uuid.uuid4()` is implemented to provide a random `UUID` instance compliant to RFC 4122 pg.14 (https://tools.ietf.org/html/rfc4122#section-4.4)

Includes unit test for all supported UUID creation methods.