### PR TITLE
copy: declare dependency on types

### DIFF
--- a/copy/metadata.txt
+++ b/copy/metadata.txt
@@ -1,3 +1,4 @@
 srctype = cpython
 type = module
 version = 3.3.3-2
+depends = micropython-types


### PR DESCRIPTION
I noticed during installation and use of `micropython-copy` that it requires the `types` module.

This PR simply declares this dependency for automatic installation.