### PR TITLE
test.support: Declare dependency on unittest, io and contextlib modules.

### DIFF
--- a/test.support/metadata.txt
+++ b/test.support/metadata.txt
@@ -1,3 +1,4 @@
 srctype=micropython-lib
 type=package
 version = 0.1.3
+depends = unittest, io, contextlib

--- a/test.support/setup.py
+++ b/test.support/setup.py
@@ -17,4 +17,5 @@ setup(name='micropython-test.support',
       maintainer_email='micropython-lib@googlegroups.com',
       license='MIT',
       cmdclass={'sdist': sdist_upip.sdist},
-      packages=['test'])
+      packages=['test'],
+      install_requires=['micropython-unittest', 'micropython-io', 'micropython-contextlib'])


### PR DESCRIPTION
Declare required libraries for `test.support`

Thanks for the pointers regarding format and commit style in my last dependency PR.
This one's commit message is longer than the git standard recommendation. Would you prefer it as is, or kept shorter?