### PR TITLE
make_metadata: Prevent syntax errors in depends and extra_modules.

### DIFF
--- a/make_metadata.py
+++ b/make_metadata.py
@@ -189,10 +189,15 @@ def main():
 
         data["modules"] = "'" + data["name"].rsplit(".", 1)[0] + "'"
         if "extra_modules" in data:
-            data["modules"] += ", " + ", ".join(["'" + x.strip() + "'" for x in data["extra_modules"].split(",")])
+            extra_modules = ["'" + x.strip() + "'" for x in data["extra_modules"].split(",")]
+            if any(" " in d for d in extra_modules):
+                raise ValueError("extra_modules should be comma separated")
+            data["modules"] += ", " + ", ".join(extra_modules)
 
         if "depends" in data:
             deps = ["micropython-" + x.strip() for x in data["depends"].split(",")]
+            if any(" " in d for d in deps):
+                raise ValueError("depends should be comma separated")
             data["_inst_req_"] = ",\n      install_requires=['" + "', '".join(deps) + "']"
         else:
             data["_inst_req_"] = ""


### PR DESCRIPTION
When running `make_metadata.py` this PR adds a little extra validation when parsing the `depends` and `extra_modules`.

This check ensure there are no wayward spaces in each detected dependency, usually caused my missing the comma separator.

This is intended to prevent careless mistakes like https://github.com/pfalcon/micropython-lib/pull/6#discussion_r229497975