### PR TITLE
OS: Use add getcwd, rmdir and mkdir from uos if available

### DIFF
--- a/os/os/__init__.py
+++ b/os/os/__init__.py
@@ -79,9 +79,12 @@ else:
         buf = bytearray(512)
         return getcwd_(buf, 512)
 
-def mkdir(name, mode=0o777):
-    e = mkdir_(name, mode)
-    check_error(e)
+if hasattr(uos, "mkdir"):
+    mkdir = uos.mkdir
+else:
+    def mkdir(name, mode=0o777):
+        e = mkdir_(name, mode)
+        check_error(e)
 
 if hasattr(uos, "rename"):
     rename = uos.rename
@@ -98,9 +101,12 @@ else:
         check_error(e)
     remove = unlink
 
-def rmdir(name):
-    e = rmdir_(name)
-    check_error(e)
+if hasattr(uos, "rmdir"):
+    rmdir = uos.rmdir
+else:
+    def rmdir(name):
+        e = rmdir_(name)
+        check_error(e)
 
 def makedirs(name, mode=0o777, exist_ok=False):
     s = ""

--- a/os/os/__init__.py
+++ b/os/os/__init__.py
@@ -72,9 +72,12 @@ def raise_error():
 
 stat = uos.stat
 
-def getcwd():
-    buf = bytearray(512)
-    return getcwd_(buf, 512)
+if hasattr(uos, "getcwd"):
+    getcwd = uos.getcwd
+else:
+    def getcwd():
+        buf = bytearray(512)
+        return getcwd_(buf, 512)
 
 def mkdir(name, mode=0o777):
     e = mkdir_(name, mode)


### PR DESCRIPTION
This fixes https://github.com/pfalcon/micropython-lib/issues/15 by looking if `getcwd`, `rmdir` and `mkdir` are available in the uos module. According to the micropython documentation on https://docs.micropython.org/en/latest/library/uos.html this should be the case. Only the unix port stands out and uses libc here.