### PR TITLE
os: use chdir() from uos if available

### DIFF
--- a/os/os/__init__.py
+++ b/os/os/__init__.py
@@ -206,9 +206,12 @@ def dup(fd):
 def access(path, mode):
     return access_(path, mode) == 0
 
-def chdir(dir):
-    r = chdir_(dir)
-    check_error(r)
+if hasattr(uos, 'chdir'):
+    chdir = uos.chdir
+else:
+    def chdir(dir):
+        r = chdir_(dir)
+        check_error(r)
 
 def fork():
     r = fork_()


### PR DESCRIPTION
I forgot this one in the last commit. This should be the last missing function we need to link from os to uos for barbone usage.