### PR TITLE
Logging: Achieve CPython compliancy with test

### DIFF
--- a/logging/logging/__init__.py
+++ b/logging/logging/__init__.py
@@ -134,6 +134,7 @@ class FileHandler:
             self._f = open(filename, mode)
 
         self._f.write(record + self.terminator)
+        self._f.flush()
 
     def close(self):
         if self._f is not None:

--- a/logging/test_handlers.py
+++ b/logging/test_handlers.py
@@ -1,4 +1,3 @@
-# Note: this test is not compliant with CPython's logging module
 import os
 import logging
 from logging.handlers import RotatingFileHandler


### PR DESCRIPTION
The flush command was missing so the test couldn't work on CPython. I fixed this for the FileHandler class and removed the compliancy note from the test as it is no longer necessary.