### PR TITLE
Logging: Add custom formatters

### DIFF
--- a/logging/logging/__init__.py
+++ b/logging/logging/__init__.py
@@ -1,5 +1,6 @@
 import utime
 import sys
+import uio
 
 CRITICAL = 50
 ERROR    = 40
@@ -63,9 +64,9 @@ class Logger:
         self.log(CRITICAL, msg, *args)
 
     def exc(self, e, msg, *args):
-        self.log(ERROR, msg, *args)
-        if _stream is not None:
-            sys.print_exception(e, _stream)
+        buf = uio.StringIO()
+        sys.print_exception(e, buf)
+        self.log(ERROR, msg + "\n" + buf.getvalue(), *args)
 
     def exception(self, msg, *args):
         self.exc(sys.exc_info()[1], msg, *args)


### PR DESCRIPTION
This PR implements custom logging formatting and refers to #21.
I tried to stay close to the CPython implementation without producing too much boilerplate. Basically the micropython version of `logging` now allows defining a custom format style via `logging.basicConfig()`. So a typical logging configuration could look like this:

    >>> import logging
    >>> logging.basicConfig(format="%(asctime)s - %(name)s [%(levelname)s]: %(message)s")
    >>> logging.info("This is a test.")
    2018-12-4 17:34:0 - root [INFO]: This is a test.

**Supported features are:**
* two different formatting styles: print-f-style ("%") and str.format ("{")
* setting the logging format for the "root" formatter via basicConfig
* setting the format of a single handler via `setFormat` by using the `Formatter`class
* the following keywords can be used for formatting and actually carry useful information: `name, asctime, msecs, levelno, levelname, message`
* the following keywords are implemented but carry no useful information (yet): `pathname, lineno, exc_info, func, s_info`