### PR TITLE
uasyncio: Fixed bug in uasyncio.remove_writer

### DIFF
--- a/uasyncio/uasyncio/__init__.py
+++ b/uasyncio/uasyncio/__init__.py
@@ -57,7 +57,7 @@ class PollEventLoop(EventLoop):
         # and if that succeeds, yield IOWrite may never be called
         # for that socket, and it will never be added to poller. So,
         # ignore such error.
-        self.poller.unregister(sock, False)
+        self.poller.unregister(sock)
 
     def wait(self, delay):
         if DEBUG and __debug__:


### PR DESCRIPTION
uselect.Epoll.unregister takes only one argument. I don't know what this code does and how it works (just started to use micropython) but I had to change this to make picoweb work.