### PR TITLE
urequests: Fix bug in redirects using json input

### DIFF
--- a/urequests/urequests/__init__.py
+++ b/urequests/urequests/__init__.py
@@ -34,6 +34,11 @@ class Response:
 
 def request(method, url, data=None, json=None, headers={}, stream=None, parse_headers=True):
     redir_cnt = 1
+    if json is not None:
+        assert data is None
+        import ujson
+        data = ujson.dumps(json)
+
     while True:
         try:
             proto, dummy, host, path = url.split("/", 3)
@@ -74,17 +79,12 @@ def request(method, url, data=None, json=None, headers={}, stream=None, parse_he
                 s.write(headers[k])
                 s.write(b"\r\n")
             if json is not None:
-                assert data is None
-                import ujson
-                _data = ujson.dumps(json)
                 s.write(b"Content-Type: application/json\r\n")
-            else:
-                _data = data
-            if _data:
-                s.write(b"Content-Length: %d\r\n" % len(_data))
+            if data:
+                s.write(b"Content-Length: %d\r\n" % len(data))
             s.write(b"Connection: close\r\n\r\n")
-            if _data:
-                s.write(_data)
+            if data:
+                s.write(data)
 
             l = s.readline()
             #print(l)

--- a/urequests/urequests/__init__.py
+++ b/urequests/urequests/__init__.py
@@ -76,13 +76,15 @@ def request(method, url, data=None, json=None, headers={}, stream=None, parse_he
             if json is not None:
                 assert data is None
                 import ujson
-                data = ujson.dumps(json)
+                _data = ujson.dumps(json)
                 s.write(b"Content-Type: application/json\r\n")
-            if data:
-                s.write(b"Content-Length: %d\r\n" % len(data))
+            else:
+                _data = data
+            if _data:
+                s.write(b"Content-Length: %d\r\n" % len(_data))
             s.write(b"Connection: close\r\n\r\n")
-            if data:
-                s.write(data)
+            if _data:
+                s.write(_data)
 
             l = s.readline()
             #print(l)


### PR DESCRIPTION
When using json input, data would be set and the assert on line 77 would fail on a redirect.